### PR TITLE
Synchronized evaluateJavaScript improvement

### DIFF
--- a/XWebView/XWVInventory.swift
+++ b/XWebView/XWVInventory.swift
@@ -83,8 +83,8 @@ import Foundation
         if let provider = plugins[namespace] {
             // Load bundle
             if !provider.bundle.loaded {
-                var error : NSErrorPointer = nil
-                if !provider.bundle.loadAndReturnError(error) {
+                var error: NSError?
+                if !provider.bundle.loadAndReturnError(&error) {
                     println("ERROR: load bundle '\(provider.bundle.bundlePath)' failed")
                     return nil
                 }

--- a/XWebView/XWVObject.swift
+++ b/XWebView/XWVObject.swift
@@ -15,10 +15,12 @@
 */
 
 import Foundation
+import WebKit
 
 public class XWVObject : NSObject {
     public let namespace: String
     public unowned let channel: XWVChannel
+    public var webView: WKWebView? { return channel.webView }
     weak var origin: XWVObject!
 
     init(namespace: String, channel: XWVChannel, origin: XWVObject?) {
@@ -38,7 +40,7 @@ public class XWVObject : NSObject {
     deinit {
         if reference != 0 {
             let script = "\(origin.namespace).$releaseObject(\(reference))"
-            channel.evaluateJavaScript(script, completionHandler: nil)
+            webView?.evaluateJavaScript(script, completionHandler: nil)
         }
     }
     func wrapScriptObject(object: AnyObject?) -> AnyObject {

--- a/XWebView/XWVScriptPlugin.swift
+++ b/XWebView/XWVScriptPlugin.swift
@@ -50,7 +50,7 @@ class XWVScriptPlugin : XWVScriptObject {
             "    \(namespace).$onready();\n" +
             "    delete \(namespace).$onready;\n" +
         "}\n"
-        evaluateScript(script, onSuccess: nil)
+        webView?.evaluateJavaScript(script, completionHandler: nil)
     }
 
     deinit {
@@ -128,7 +128,7 @@ class XWVScriptPlugin : XWVScriptObject {
             assert(channel.typeInfo.hasProperty(prop))
         }
         let script = "\(namespace).$properties['\(prop)'] = \(serialize(change[NSKeyValueChangeNewKey]))"
-        evaluateScript(script, onSuccess: nil)
+        webView?.evaluateJavaScript(script, completionHandler: nil)
     }
     private func startKVO() {
         for prop in channel.typeInfo.allProperties {

--- a/XWebView/XWVThread.swift
+++ b/XWebView/XWVThread.swift
@@ -25,7 +25,7 @@ class XWVThread : NSThread {
 
     override func main() {
         do {
-            switch  Int(CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60, Boolean(1))) {
+            switch Int(CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60, Boolean(1))) {
                 case kCFRunLoopRunFinished:
                     // No input source, add a timer (which will never fire) to avoid spinning.
                     let interval = NSDate.distantFuture().timeIntervalSinceNow

--- a/XWebViewTests/ConstructorPlugin.swift
+++ b/XWebViewTests/ConstructorPlugin.swift
@@ -30,7 +30,7 @@ class ConstructorPlugin : XWVTestCase {
         }
         func finalizeForScript() {
             if property == 456 {
-                scriptObject?.evaluateScript("fulfill('finalizeForScript')", onSuccess: nil)
+                scriptObject?.webView?.evaluateJavaScript("fulfill('finalizeForScript')", completionHandler: nil)
             }
         }
         class func isSelectorForConstructor(selector: Selector) -> Bool {


### PR DESCRIPTION
- It works on main thread!
- It handles timeout (3 seconds).
- Added an out parameter for error.
- Moved to WKWebView extension.
- Rename evaluateScript to evaluateExpression because it doesn't support
  statements.
