### PR TITLE
Fix: loadHTMLString must start a local server even though in iOS9.x

### DIFF
--- a/XWebView/XWebView.swift
+++ b/XWebView/XWebView.swift
@@ -102,19 +102,34 @@ extension WKWebView {
     // See http://nshipster.com/swift-objc-runtime/
     private static var initialized: dispatch_once_t = 0
     public override class func initialize() {
-        //if #available(iOS 9, *) { return }
         guard self == WKWebView.self else { return }
         dispatch_once(&initialized) {
-            let selector = Selector("loadFileURL:allowingReadAccessToURL:")
-            let method = class_getInstanceMethod(self, Selector("_loadFileURL:allowingReadAccessToURL:"))
-            assert(method != nil)
-            if class_addMethod(self, selector, method_getImplementation(method), method_getTypeEncoding(method)) {
-                print("iOS 8.x")
-                method_exchangeImplementations(
-                    class_getInstanceMethod(self, Selector("loadHTMLString:baseURL:")),
-                    class_getInstanceMethod(self, Selector("_loadHTMLString:baseURL:"))
-                )
-            }
+            let loadFileURLSelector = Selector("loadFileURL:allowingReadAccessToURL:")
+            let loadHTMLStringSelector = Selector("loadHTMLString:baseURL:")
+            let customLoadHTMLStringSelector = Selector("_loadHTMLString:baseURL:")
+            let customLoadFileURLSelector = Selector("_loadFileURL:allowingReadAccessToURL:")
+            
+            let loadFileURLMethod = class_getInstanceMethod(
+                self,
+                customLoadFileURLSelector
+            )
+            let loadHTMLStringMethod = class_getInstanceMethod(
+                self,
+                customLoadHTMLStringSelector
+            )
+            
+            assert(loadFileURLMethod != nil && loadHTMLStringMethod != nil)
+            
+            class_addMethod(
+                self,
+                loadFileURLSelector,
+                method_getImplementation(loadFileURLMethod),
+                method_getTypeEncoding(loadFileURLMethod)
+            )
+            method_exchangeImplementations(
+                class_getInstanceMethod(self, loadHTMLStringSelector),
+                class_getInstanceMethod(self, customLoadHTMLStringSelector)
+            )
         }
     }
 
@@ -137,12 +152,18 @@ extension WKWebView {
         return nil
     }
 
+    // Although iOS 9.x loadHTMLString and loadData can't use baseURL with file protocol access.
+    // But for Simulator you can use loadHTMLString and loadData with file:/// as baseURL and access
+    // all of your resources. Accessing local data is restricted for devices and the unique folder
+    // that you can access is tmp folder.
+    //
+    // It continues to be necessary with you pretend to render pages such as dynamic templates.
     @objc private func _loadHTMLString(html: String, baseURL: NSURL) -> WKNavigation? {
         guard baseURL.fileURL else {
             // call original method implementation
             return _loadHTMLString(html, baseURL: baseURL)
         }
-
+        
         let fileManager = NSFileManager.defaultManager()
         var isDirectory: ObjCBool = false
         if fileManager.fileExistsAtPath(baseURL.path!, isDirectory: &isDirectory) && isDirectory {

--- a/XWebViewTests/XWebViewTests.swift
+++ b/XWebViewTests/XWebViewTests.swift
@@ -48,4 +48,28 @@ class XWebViewTests: XWVTestCase {
             waitForExpectationsWithTimeout(2, handler: nil)
         }
     }
+    
+    func testLoadHtmlStringWithNoBaseURL() {
+        expectationWithDescription("about:blank")
+        webview.loadHTMLString("<html><body><script>fulfill(document.documentURI);</script></body></html>", baseURL: nil)
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
+    
+    func testLoadHtmlStringWithFileAsBaseURL() {
+        let bundle = NSBundle(identifier:"org.xwebview.XWebViewTests")
+        let baseURL = bundle?.bundleURL.URLByAppendingPathComponent("www")
+        let split = "/:\\/\\/|:/"
+        let replace = "/\\./g"
+        expectationWithDescription("127001") //Original: http://127.0.0.1
+        webview.loadHTMLString(
+            "<html>" +
+                "<body>" +
+                    "<script>" +
+                    "fulfill(document.documentURI.split(\(split))[1].replace(\(replace),''));" +
+                    "</script>" +
+                "</body>" +
+            "</html>",
+            baseURL: baseURL)
+        waitForExpectationsWithTimeout(2, handler: nil)
+    }
 }


### PR DESCRIPTION
iOS 9.x have [`loadData:MIMEType:characterEncodingName:baseURL:`](https://developer.apple.com/library/ios/documentation/WebKit/Reference/WKWebView_Ref/#//apple_ref/occ/instm/WKWebView/loadData:MIMEType:characterEncodingName:baseURL:) and the old [`loadHTMLString:baseURL:`](https://developer.apple.com/library/ios/documentation/WebKit/Reference/WKWebView_Ref/#//apple_ref/occ/instm/WKWebView/loadHTMLString:baseURL:). 

If you run on a simulator you can use any baseURL pointing to bundle resources. But for iOS devices you can't do that because file access is restrict to `tmp` folder. So It's still necessary to emulate a local server to fetch those resources.
