### PR TITLE
Update project settings to Swift3

### DIFF
--- a/XWebView.xcodeproj/project.pbxproj
+++ b/XWebView.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 					};
 					EE62683419FA323900EFC3F8 = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};


### PR DESCRIPTION
Hello,

I juste downloaded the latest snapshot from master, but Xcode 8.2 (8C38) complained about source code not being converted to the latest Swift 3 syntax.
In this PR I added two simple changes:

 - update the project settings to latest Swift 3 (the code itself is ok, just changed a value in the .pbxproj)
 - fix a few Xcode wanings along the way

Regards to the team