### PR TITLE
Fixed compiling with Swift 3.1

### DIFF
--- a/XWebView/XWVMetaObject.swift
+++ b/XWebView/XWVMetaObject.swift
@@ -85,7 +85,6 @@ class XWVMetaObject {
         var methods = instanceMethods(forProtocol: XWVScripting.self)
         methods.remove(#selector(XWVScripting.invokeDefaultMethod(withArguments:)))
         return methods.union([
-            #selector(NSObject.deinit),
             #selector(NSObject.copy)
         ])
     }()

--- a/XWebViewTests/XWVMetaObjectTest.swift
+++ b/XWebViewTests/XWVMetaObjectTest.swift
@@ -105,6 +105,25 @@ class XWVMetaObjectTest: XCTestCase {
         XCTAssertTrue(meta["method"] == nil)
     }
 
+    func testForSpecialExclusion() {
+        class TestForExclusion: XWVScripting {
+            @objc deinit {
+                print("ensuring deinit is not optimized out")
+            }
+            @objc func copy() -> Any {
+                return TestForExclusion()
+            }
+            @objc func copy(with zone: NSZone? = nil) -> Any {
+                return TestForExclusion()
+            }
+            @objc func method() {}
+        }
+        let meta = XWVMetaObject(plugin: TestForExclusion.self)
+        XCTAssertTrue(meta["dealloc"] == nil)
+        XCTAssertTrue(meta["deinit"] == nil)
+        XCTAssertTrue(meta["copy"] == nil)
+    }
+
     func testForFunction() {
         class TestForFunction : XWVScripting {
             @objc func defaultMethod() {}


### PR DESCRIPTION
Xcode 8.3 introduced Swift 3.1 which forbids to access deinitializers. The code
started failing to compile with "Deinitializers cannot be accessed".  Looking
closer it seems the code in question isn't even needed, deinit defined in Swift
is not exposed by class_copyMethodList() function.