### PR TITLE
Fixed compiler warning

### DIFF
--- a/XWebView/XWVChannel.swift
+++ b/XWebView/XWVChannel.swift
@@ -93,7 +93,7 @@ public class XWVChannel : NSObject, WKScriptMessageHandler {
         webView?.configuration.userContentController.removeScriptMessageHandler(forName: id)
         userScript = nil
         identifier = nil
-        log("+Plugin object \(plugin) is unbound from \(namespace)")
+        log("+Plugin object \(plugin?.description ?? "unknown") is unbound from \(namespace)")
     }
 
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {


### PR DESCRIPTION
Swift 3.1 is quite strict on outputting optionals inside string interpolations.